### PR TITLE
Some bug fixes for easy debugging

### DIFF
--- a/custom_components/ecole_directe/ecole_directe_helper.py
+++ b/custom_components/ecole_directe/ecole_directe_helper.py
@@ -472,7 +472,7 @@ def get_grades_evaluations(token, eleve, annee_scolaire, config_path):
             token,
             f"{APIURL}/eleves/{eleve.eleve_id}/notes.awp?verbe=get&v={APIVERSION}",
             f"data={{'anneeScolaire': '{annee_scolaire}'}}",
-            f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_grades_evaluations",
+            f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_grades_evaluations.json",
         )
 
     if "data" not in json_resp:

--- a/custom_components/ecole_directe/ecole_directe_helper.py
+++ b/custom_components/ecole_directe/ecole_directe_helper.py
@@ -373,7 +373,7 @@ def get_messages(token, id, eleve, annee_scolaire, config_path):
     )
 
 
-def get_homeworks_by_date(token, eleve, date, config_path, idx):
+def get_homeworks_by_date(token, eleve, date, config_path):
     """get homeworks by date"""
 
     if DEBUG_ON:
@@ -388,7 +388,7 @@ def get_homeworks_by_date(token, eleve, date, config_path, idx):
         token,
         f"{APIURL}/Eleves/{eleve.eleve_id}/cahierdetexte/{date}.awp?verbe=get&v={APIVERSION}",
         None,
-        f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_homeworks_by_date_{str(idx)}.json"
+        f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_homeworks_by_date_{date}.json"
     )
     if "data" in json_resp:
         return json_resp["data"]
@@ -420,7 +420,7 @@ def get_homeworks(token, eleve, config_path, decode_html):
     for key in data.keys():
         for idx, homework_json in enumerate(data[key]):
             homeworks_by_date_json = get_homeworks_by_date(
-                token, eleve, key, config_path, idx
+                token, eleve, key, config_path
             )
             for matiere in homeworks_by_date_json["matieres"]:
                 if "aFaire" in matiere :

--- a/custom_components/ecole_directe/ecole_directe_helper.py
+++ b/custom_components/ecole_directe/ecole_directe_helper.py
@@ -423,7 +423,7 @@ def get_homeworks(token, eleve, config_path, decode_html):
                 token, eleve, key, config_path, idx
             )
             for matiere in homeworks_by_date_json["matieres"]:
-                if "aFaire" in matiere and matiere["aFaire"]["effectue"] is False:
+                if "aFaire" in matiere :
                     if matiere["id"] == homework_json["idDevoir"]:
                         hw = get_homework(matiere, key, decode_html)
                         homeworks.append(hw)

--- a/custom_components/ecole_directe/ecole_directe_helper.py
+++ b/custom_components/ecole_directe/ecole_directe_helper.py
@@ -369,7 +369,7 @@ def get_messages(token, id, eleve, annee_scolaire, config_path):
         token,
         f"{APIURL}/eleves/{eleve.eleve_id}/messages.awp?force=false&typeRecuperation=received&idClasseur=0&orderBy=date&order=desc&query=&onlyRead=&page=0&itemsPerPage=100&getAll=0&verbe=get&v={APIVERSION}",
         payload,
-        config_path + INTEGRATION_PATH + "get_messages_eleve.json",
+        f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_messages_eleve.json",
     )
 
 
@@ -388,7 +388,7 @@ def get_homeworks_by_date(token, eleve, date, config_path, idx):
         token,
         f"{APIURL}/Eleves/{eleve.eleve_id}/cahierdetexte/{date}.awp?verbe=get&v={APIVERSION}",
         None,
-        config_path + INTEGRATION_PATH + "get_homeworks_by_date_" + str(idx) + ".json",
+        f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_homeworks_by_date_{str(idx)}.json"
     )
     if "data" in json_resp:
         return json_resp["data"]
@@ -408,7 +408,7 @@ def get_homeworks(token, eleve, config_path, decode_html):
             token,
             f"{APIURL}/Eleves/{eleve.eleve_id}/cahierdetexte.awp?verbe=get&v={APIVERSION}",
             None,
-            config_path + INTEGRATION_PATH + "get_homeworks.json",
+            f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_homeworks.json",
         )
 
     if "data" not in json_resp:
@@ -472,7 +472,7 @@ def get_grades_evaluations(token, eleve, annee_scolaire, config_path):
             token,
             f"{APIURL}/eleves/{eleve.eleve_id}/notes.awp?verbe=get&v={APIVERSION}",
             f"data={{'anneeScolaire': '{annee_scolaire}'}}",
-            config_path + INTEGRATION_PATH + "get_grades_evaluations.json",
+            f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_grades_evaluations",
         )
 
     if "data" not in json_resp:
@@ -595,7 +595,8 @@ def get_vie_scolaire(token, eleve, config_path):
             token,
             f"{APIURL}/eleves/{eleve.eleve_id}/viescolaire.awp?verbe=get&v={APIVERSION}",
             "data={}",
-            config_path + INTEGRATION_PATH + "get_vie_scolaire.json",
+            f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_vie_scolaire.json",
+
         )
 
     if "data" not in json_resp:
@@ -677,7 +678,7 @@ def get_lessons(token, eleve, date_debut, date_fin, config_path, lunch_break_tim
             token,
             f"{APIURL}/E/{eleve.eleve_id}/emploidutemps.awp?verbe=get&v={APIVERSION}",
             f"data={{'dateDebut': '{date_debut}','dateFin': '{date_fin}','avecTrous': false}}",
-            config_path + INTEGRATION_PATH + "get_lessons.json",
+            f"{config_path + INTEGRATION_PATH}{eleve.eleve_id}_get_lessons.json",
         )
 
     if "data" not in json_resp:

--- a/custom_components/ecole_directe/sensor.py
+++ b/custom_components/ecole_directe/sensor.py
@@ -200,7 +200,7 @@ class EDHomeworksSensor(EDGenericSensor):
             for homework in homeworks:
                 if not homework["done"]:
                     todo_counter += 1
-                    attributes.append(homework)
+                attributes.append(homework)
             if attributes is not None:
                 attributes.sort(key=operator.itemgetter("date"))
         else:


### PR DESCRIPTION
Ajout des id des élèves dans le nom des json afin qu'ils ne soient pas écrasés en cas de plusieurs enfants (utile seulement pour du debug)

Ajout des devoirs  effectues au sensor _homework qui étaient absent jusqu’à présent alors que géré par la card pronote

Oubli de l'extension d'un fichier json dans le commit initial

Correction de la facon dont sont nommés les fichiers json de get_homework_by_date, de telle facon nous avons désormais tous les fichiers (utile seulement pour du debug)