### PR TITLE
Add devcontainer configuration and update linting settings

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "version": "1.0.6",
+      "resolved": "ghcr.io/devcontainers-extra/features/apt-packages@sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd",
+      "integrity": "sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    }
+  }
+}

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -13,20 +13,15 @@ ignore = [
     "COM812", # incompatible with formatter
     "ISC001", # incompatible with formatter
 
-    "A005",   # It is just wrong
-    "ANN401", # Opiniated warning on disallowing dynamically typed expressions
-    "D203",   # Conflicts with other rules
+
     "D213",   # Conflicts with other rules
     "RUF012", # Just broken
-    "TC006",  # Checks for unquoted type expressions in typing.cast() calls.
     "TID252", # Relative imports
 
     # Formatter conflicts
-    "COM812",
     "COM819",
     "D206",
     "E501",
-    "ISC001",
     "Q000",
     "Q001",
     "Q002",
@@ -61,3 +56,6 @@ keep-runtime-typing = true
 
 [lint.mccabe]
 max-complexity = 25
+
+[lint.pydocstyle]
+convention = "google"

--- a/custom_components/ecole_directe/entity_utils/state_helpers.py
+++ b/custom_components/ecole_directe/entity_utils/state_helpers.py
@@ -27,7 +27,7 @@ def format_state_value(value: Any, unit: str | None = None) -> str:
     if isinstance(value, bool):
         return "on" if value else "off"
 
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         formatted = f"{value:.2f}" if isinstance(value, float) else str(value)
         return f"{formatted} {unit}" if unit else formatted
 

--- a/custom_components/ecole_directe/service_actions/service.py
+++ b/custom_components/ecole_directe/service_actions/service.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.exceptions import HomeAssistantError
 
-from custom_components.ecole_directe.const import DOMAIN, LOGGER
+from custom_components.ecole_directe.const import LOGGER
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
@@ -34,6 +34,5 @@ async def async_handle_devoir_effectue(
         )
     except Exception as err:
         LOGGER.exception("Error on service devoir_effectue call")
-        raise HomeAssistantError(
-            f"Failed to mark homework as done: {err}"
-        ) from err
+        msg = f"Failed to mark homework as done: {err}"
+        raise HomeAssistantError(msg) from err

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,13 +2,14 @@
 #
 # Note: The following are already provided by HA's requirements_test.txt:
 #   - pytest and pytest plugins (pytest-asyncio, pytest-aiohttp, pytest-cov, etc.)
-#   - ruff (linting and formatting) via requirements_test_pre_commit.txt
 #   - mypy-dev (type checking - we use pyright instead)
-#   - codespell (spell checking) via requirements_test_pre_commit.txt
 #   - pre-commit (hook framework)
 #   - pylint (linting)
 #
 # Install with: uv pip install -r requirements_dev.txt
+
+# Linting and formatting
+ruff==0.5.3
 
 # Type Checking
 # HA Core uses mypy, but we prefer pyright for better IDE integration and speed

--- a/script/lint-check
+++ b/script/lint-check
@@ -32,9 +32,6 @@ if [[ -z ${VIRTUAL_ENV:-} ]]; then
     fi
 fi
 
-log_header "Checking code format"
-ruff format . --check
-
 log_header "Checking code with Ruff"
 ruff check .
 


### PR DESCRIPTION
- Introduced devcontainer-lock.json with necessary features and versions.
- Updated .ruff.toml to refine linting rules and added pydocstyle configuration.
- Modified state_helpers.py to use union type for value checks.
- Cleaned up service.py by removing unused imports and simplifying error handling.
- Updated requirements_dev.txt to include ruff for linting.
- Adjusted lint-check script to remove formatting checks.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- If this PR fixes an issue, please link to the issue here -->

Fixes #(issue)

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] My code follows the code style of this project (run `script/lint`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the translations if needed

## Testing

<!-- Please describe how you tested your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
